### PR TITLE
typo from last release fixed urinary-bladder.hhtml

### DIFF
--- a/reference-entity-ids.tsv
+++ b/reference-entity-ids.tsv
@@ -61,7 +61,7 @@ HBM462.NJKR.937	https://entity.api.hubmapconsortium.org/redirect/HBM462.NJKR.937
 HBM835.WCGP.479	https://entity.api.hubmapconsortium.org/redirect/HBM835.WCGP.479	https://hubmapconsortium.github.io/ccf-releases/v1.1/docs/asct-b/prostate.html	https://doi.org/10.48539/HBM835.WCGP.479
 HBM736.PJQV.368	https://entity.api.hubmapconsortium.org/redirect/HBM736.PJQV.368	https://hubmapconsortium.github.io/ccf-releases/v1.1/docs/asct-b/small-intestine.html	https://doi.org/10.48539/HBM736.PJQV.368
 HBM882.LRSF.394	https://entity.api.hubmapconsortium.org/redirect/HBM882.LRSF.394	https://hubmapconsortium.github.io/ccf-releases/v1.1/docs/asct-b/ureter.html	https://doi.org/10.48539/HBM882.LRSF.394
-HBM546.CKGW.888	https://entity.api.hubmapconsortium.org/redirect/HBM546.CKGW.888	https://hubmapconsortium.github.io/ccf-releases/v1.1/docs/asct-b/urinary-bladder.hhtml	https://doi.org/10.48539/HBM546.CKGW.888
+HBM546.CKGW.888	https://entity.api.hubmapconsortium.org/redirect/HBM546.CKGW.888	https://hubmapconsortium.github.io/ccf-releases/v1.1/docs/asct-b/urinary-bladder.html	https://doi.org/10.48539/HBM546.CKGW.888
 HBM265.DQZW.372	https://entity.api.hubmapconsortium.org/redirect/HBM265.DQZW.372	https://hubmapconsortium.github.io/ccf-releases/v1.1/docs/asct-b/uterus.html	https://doi.org/10.48539/HBM265.DQZW.372
 HBM333.RJDF.478	https://entity.api.hubmapconsortium.org/redirect/HBM333.RJDF.478	https://hubmapconsortium.github.io/ccf-releases/v1.1/docs/ref-organs/pelvis-male.html	https://doi.org/10.48539/HBM333.RJDF.478
 HBM678.LPCR.586	https://entity.api.hubmapconsortium.org/redirect/HBM678.LPCR.586	https://hubmapconsortium.github.io/ccf-releases/v1.1/docs/ref-organs/pelvis-female.html	https://doi.org/10.48539/HBM678.LPCR.586


### PR DESCRIPTION
typo from last release fixed (removed extra h from hhtml) https://hubmapconsortium.github.io/ccf-releases/v1.1/docs/asct-b/urinary-bladder.hhtml