### PR TITLE
fixed link to ORCID

### DIFF
--- a/v1.2/markdown/omap/omap-kidney-codex.md
+++ b/v1.2/markdown/omap/omap-kidney-codex.md
@@ -12,7 +12,7 @@ The OMAP kidney panel was designed for CODEX (CO Detection by IndEXing) of fresh
 | **Project Lead:** | Andrea J. Radtke; Katy B&ouml;rner; Neil Kelleher; Ronald N. Germain |
 | **Project Lead ORCID:** | [0000-0003-4379-8967](https://orcid.org/0000-0003-4379-8967); [0000-0002-3321-6137](https://orcid.org/0000-0002-3321-6137); [0000-0002-8815-3372](https://orcid.org/0000-0002-8815-3372); [0000-0003-1495-9143](https://orcid.org/0000-0003-1495-9143)|
 | **Reviewer(s):** | Andrea J. Radtke; Ellen M. Quardokus; Christopher Werlein
-| **Reviewer ORCID(s):** |[0000-0003-4379-8967](https://orcid.org/0000-0003-4379-8967); [0000-0001-7655-4833](https://orcid.org/0000-0001-7655-4833); [0000-0002-7694-4257](0000-0002-7694-4257)|
+| **Reviewer ORCID(s):** |[0000-0003-4379-8967](https://orcid.org/0000-0003-4379-8967); [0000-0001-7655-4833](https://orcid.org/0000-0001-7655-4833); [0000-0002-7694-4257](https://orcid.org/0000-0002-7694-4257)|
 | **Creation Date:** | 2022-05-06 |
 | **License:** | Creative Commons Attribution 4.0 International ([CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)) |
 | **Publisher:** | HuBMAP |


### PR DESCRIPTION
Added https://orcid.org/ to ORCID for Christopher Werlein