### PR TITLE
Corrected url typo for skin csv vs xlsx

### DIFF
--- a/v1.3/markdown/omap/omap-4-skin-cell-dive.md
+++ b/v1.3/markdown/omap/omap-4-skin-cell-dive.md
@@ -17,7 +17,7 @@ OMAP-4 was designed for Cell DIVE multiplexed imaging of formalin-fixed paraffin
 | **Funder:** | National Institutes of Health, National Institute of Allergy and Infectious Disease, National Cancer Institute |
 | **Award Number:** |OT2OD026671, NIH 5UH3CA246594-02, UH3 CA246635, UH3 CA246594-01|
 | **HuBMAP ID:** | HBM577.SBHH.454 |
-| **Data Table:** | OMAP-4 Organ Mapping Antibody Panel (OMAP) for Multiplexed Antibody-Based Imaging of Human Skin with Cell DIVE, v1.1 [CSV](https://hubmapconsortium.github.io/ccf-releases/v1.3/omap/omap-4-skin-cell-dive.csv) [Excel](https://hubmapconsortium.github.io/ccf-releases/v1.3/omap/omap-4-skin-cell-dive.csvxlsx) |
+| **Data Table:** | OMAP-4 Organ Mapping Antibody Panel (OMAP) for Multiplexed Antibody-Based Imaging of Human Skin with Cell DIVE, v1.1 [CSV](https://hubmapconsortium.github.io/ccf-releases/v1.3/omap/omap-4-skin-cell-dive.csv) [Excel](https://hubmapconsortium.github.io/ccf-releases/v1.3/omap/omap-4-skin-cell-dive.xlsx) |
 | **DOI:** | [https://doi.org/10.48539/HBM577.SBHH.454](https://doi.org/10.48539/HBM577.SBHH.454) |
 | **How to Cite This Data Table:** |Liz McDonough, Chrystal Chadwick, and Fiona Ginty. OMAP-4  Organ Mapping Antibody Panel (OMAP) for Multiplexed Antibody-Based Imaging of Human Skin with Cell DIVE, v1.1. https://doi.org/10.48539/HBM577.SBHH.454, Accessed December 15, 2022.|
 | **How to Cite OMAP Tables Overall:** | Hickey, John W., Elizabeth K. Neumann, Andrea J. Radtke, Jeannie M. Camarillo, Rebecca T. Beuschel, Alexandre Albanese, Elizabeth McDonough, et al. 2021. “Spatial Mapping of Protein Composition and Tissue Organization: A Primer for Multiplexed Antibody-Based Imaging.” *Nature Methods*, November. https://doi.org/10.1038/s41592-021-01316-y. |


### PR DESCRIPTION
Correct url typo had box csv and xlsx in name  to this: omap-4-skin-cell-dive.xlsx
Was this: [Excel](https://hubmapconsortium.github.io/ccf-releases/v1.3/omap/omap-4-skin-cell-dive.csvxlsx)